### PR TITLE
Disable yarn:install task

### DIFF
--- a/lib/tasks/allinson_flex.rake
+++ b/lib/tasks/allinson_flex.rake
@@ -6,16 +6,16 @@ ensure
   Webpacker.logger = old_logger
 end
 
-namespace :yarn do
-  task :install do
-    Dir.chdir(File.join(__dir__, "../..")) do
-      ensure_log_goes_to_stdout do
-        Webpacker.logger.info 'starting flexible metadata yarn install'
-        system "yarn install --no-progress --production"
-      end
-    end
-  end
-end
+# namespace :yarn do
+#   task :install do
+#     Dir.chdir(File.join(__dir__, "../..")) do
+#       ensure_log_goes_to_stdout do
+#         Webpacker.logger.info 'starting flexible metadata yarn install'
+#         system "yarn install --no-progress --production"
+#       end
+#     end
+#   end
+# end
 
 namespace :allinson_flex do
   namespace :webpacker do


### PR DESCRIPTION
This is task is getting called when running the application's yarn:install task, causing assets to be compiled and stored in the gem's directory.