### PR TITLE
Resolve old node-gyp errors with @rails/webpacker upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@babel/preset-react": "^7.9.4",
-    "@rails/webpacker": "4.2.2",
+    "@rails/webpacker": "^5.4.3",
     "@rjsf/core": "^2.0.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "immutability-helper": "^3.0.2",


### PR DESCRIPTION
Older webpacker results in errors when building the older node/node-sass/node-gyp stack that we are held back to.

You can test the change within [essi](https://github.com/IU-Libraries-Joint-Development/essi) by directly running:
```sh
$ bundle exec rake allinson_flex:webpacker:compile
```
or
```sh
$ bundle exec rake assets:precompile # is decorated to call allinson_flex:webpacker:compile
```
and watch the output.  With the older webpacker, you should see errors around compiling node-gyp.  You can test the change by going to the gem used in your local app:
```sh
$ bundle show allinson_flex
```
making the same change made in this PR, re-running asset precompilation, and seeing that it no longer generates node-gyp errors.  (Note that it will generate them for the essi stack running assets:precompile for local essi assets, unless you make the corresponding change to the local package.json, as well -- that will go into a separate essi PR.)