### PR TITLE
Avoid n+1 query in constructor

### DIFF
--- a/app/services/allinson_flex/allinson_flex_constructor.rb
+++ b/app/services/allinson_flex/allinson_flex_constructor.rb
@@ -167,9 +167,10 @@ module AllinsonFlex
 
       def self.intersection_properties(klass, context = nil)
         if klass && context
-          context.available_properties.map(&:profile_property) & klass.available_properties.map(&:profile_property)
+          context.available_properties.includes(profile_property: :texts).map(&:profile_property) &
+            klass.available_properties.includes(profile_property: :texts).map(&:profile_property)
         else
-          klass.available_properties.map(&:profile_property)
+          klass.available_properties.includes(profile_property: :texts).map(&:profile_property)
         end
       end
 


### PR DESCRIPTION
Eager loads profile_properties and their texts to avoid n+1 queries when saving a new profile version. Alternatively, this could be done in the ProfileClass and ProfileContext models.